### PR TITLE
Ability to extract exceptions to Monolog context

### DIFF
--- a/src/MonologTarget.php
+++ b/src/MonologTarget.php
@@ -11,6 +11,11 @@ use Illuminate\Support\Collection;
 class MonologTarget extends Target
 {
     /**
+     * @var bool Determines if exceptions (passed as first element in log record array) should be extracted.
+     */
+    public $extractExceptionsToContext = false;
+
+    /**
      * @var Logger
      */
     private $logger;
@@ -72,7 +77,7 @@ class MonologTarget extends Target
     private function getMessages(): Collection
     {
         return collect($this->messages)->map(function ($message) {
-            return new Yii2LogMessage($message);
+            return new Yii2LogMessage($message, $this->extractExceptionsToContext);
         });
     }
 }

--- a/src/MonologTarget.php
+++ b/src/MonologTarget.php
@@ -11,11 +11,6 @@ use Illuminate\Support\Collection;
 class MonologTarget extends Target
 {
     /**
-     * @var bool Determines if exceptions (passed as first element in log record array) should be extracted.
-     */
-    public $extractExceptionsToContext = false;
-
-    /**
      * @var Logger
      */
     private $logger;
@@ -77,7 +72,7 @@ class MonologTarget extends Target
     private function getMessages(): Collection
     {
         return collect($this->messages)->map(function ($message) {
-            return new Yii2LogMessage($message, $this->extractExceptionsToContext);
+            return new Yii2LogMessage($message);
         });
     }
 }

--- a/src/Yii2LogMessage.php
+++ b/src/Yii2LogMessage.php
@@ -41,13 +41,25 @@ class Yii2LogMessage
     private $yiiLogLevel;
 
     /**
+     * @var \Throwable|null
+     */
+    private $exception;
+
+    /**
      * Initializes a new Yii2LogMessage.
      *
      * @param array $message
+     * @param bool $exceptionInContext
      */
-    public function __construct(array $message)
+    public function __construct(array $message, bool $exceptionInContext = false)
     {
-        $this->setMessage($message[0]);
+        if (true === $exceptionInContext && $message[0] instanceof \Throwable) {
+            $this->exception = $message[0];
+            $this->setMessage(\get_class($message[0]) . ': ' . $message[0]->getMessage());
+        } else {
+            $this->setMessage($message[0]);
+        }
+
         $this->yiiLogLevel = $message[1];
 
         if (isset($message[2])) {
@@ -86,6 +98,14 @@ class Yii2LogMessage
     }
 
     /**
+     * @return null|\Throwable
+     */
+    public function getException()
+    {
+        return $this->exception;
+    }
+
+    /**
      * Returns the context for the Yii2LogMessage.
      *
      * @return array
@@ -104,6 +124,10 @@ class Yii2LogMessage
 
         if ($this->memory !== null) {
             $context['memory'] = $this->memory;
+        }
+
+        if ($this->exception !== null) {
+            $context['exception'] = $this->exception;
         }
 
         return $context;

--- a/src/Yii2LogMessage.php
+++ b/src/Yii2LogMessage.php
@@ -49,16 +49,10 @@ class Yii2LogMessage
      * Initializes a new Yii2LogMessage.
      *
      * @param array $message
-     * @param bool $exceptionInContext
      */
-    public function __construct(array $message, bool $exceptionInContext = false)
+    public function __construct(array $message)
     {
-        if (true === $exceptionInContext && $message[0] instanceof \Throwable) {
-            $this->exception = $message[0];
-            $this->setMessage(\get_class($message[0]) . ': ' . $message[0]->getMessage());
-        } else {
-            $this->setMessage($message[0]);
-        }
+        $this->setMessage($message[0]);
 
         $this->yiiLogLevel = $message[1];
 
@@ -158,10 +152,9 @@ class Yii2LogMessage
      */
     private function setMessage($message)
     {
-        if (! \is_string($message)) {
-            $message = $this->convertYiisMessageToString($message);
-        }
-        $this->message = $message;
+        $this->message = ! \is_string($message)
+            ? $this->convertYiisMessageToString($message)
+            : $message;
     }
 
     /**
@@ -173,8 +166,10 @@ class Yii2LogMessage
      */
     private function convertYiisMessageToString($message): string
     {
-        if ($message instanceof \Throwable || $message instanceof \Exception) {
-            return (string) $message;
+        if ($message instanceof \Throwable) {
+            $this->exception = $message;
+
+            return \get_class($message) . ': ' . $message->getMessage();
         }
 
         return VarDumper::export($message);

--- a/tests/Integration/MonologTargetTest.php
+++ b/tests/Integration/MonologTargetTest.php
@@ -44,14 +44,6 @@ class MonologTargetTest extends TestCase
                             'class' => MonologTarget::class,
                             'channel' => $channelName,
                             'levels' => ['error', 'warning'],
-                            'except' => ['sentry'],
-                        ],
-                        [
-                            'class' => MonologTarget::class,
-                            'channel' => $channelName,
-                            'levels' => ['error'],
-                            'categories' => ['sentry'],
-                            'extractExceptionsToContext' => true,
                         ],
                     ],
                 ],
@@ -106,12 +98,12 @@ class MonologTargetTest extends TestCase
     }
 
     /** @test */
-    public function it_should_be_able_to_extract_exceptions_into_context()
+    public function it_should_extract_exceptions_into_context()
     {
         $logger = Yii::$app->log->getLogger();
         $exception = new \RuntimeException('Boom!');
 
-        $logger->log($exception, Logger::LEVEL_ERROR, 'sentry');
+        $logger->log($exception, Logger::LEVEL_ERROR, 'exceptions');
         $logger->flush(true);
 
         $logMessage = $this->handler->getRecords()[0];

--- a/tests/Unit/Yii2LogMessageTest.php
+++ b/tests/Unit/Yii2LogMessageTest.php
@@ -101,23 +101,14 @@ class Yii2LogMessageTest extends TestCase
     }
 
     /** @test */
-    public function yiis_messages_can_be_also_arrays_or_exceptions_instead_of_plain_strings()
+    public function yiis_messages_can_be_also_arrays_instead_of_plain_strings()
     {
-        $runTimeException = new \RuntimeException('a runtime exception');
         $expectedArrayOutput = VarDumper::export(['an array as the log message']);
         $expectedMultiLevelArrayOutput = VarDumper::export([
             'an array as the log message' => ['with' => ['nested' => 'arrays']],
         ]);
 
         $messagesAndTheirExpectedResultsMap = [
-            (string) $runTimeException => [
-                $runTimeException,
-                Logger::LEVEL_ERROR,
-                'application',
-                10,
-                $this->getDummyStackTrace(),
-                123,
-            ],
             $expectedArrayOutput => [
                 ['an array as the log message'],
                 Logger::LEVEL_ERROR,
@@ -144,7 +135,7 @@ class Yii2LogMessageTest extends TestCase
     }
 
     /** @test */
-    public function exceptions_can_be_extracted_to_monolog_context()
+    public function exceptions_are_extracted_to_monolog_context()
     {
         $runTimeException = new \RuntimeException('a runtime exception');
         $message = [
@@ -155,7 +146,7 @@ class Yii2LogMessageTest extends TestCase
             $this->getDummyStackTrace(),
             123,
         ];
-        $logMessage = new Yii2LogMessage($message, true);
+        $logMessage = new Yii2LogMessage($message);
 
         $this->assertEquals('RuntimeException: a runtime exception', $logMessage->getMessage());
         $this->assertEquals($runTimeException, $logMessage->getException());

--- a/tests/Unit/Yii2LogMessageTest.php
+++ b/tests/Unit/Yii2LogMessageTest.php
@@ -143,6 +143,25 @@ class Yii2LogMessageTest extends TestCase
         }
     }
 
+    /** @test */
+    public function exceptions_can_be_extracted_to_monolog_context()
+    {
+        $runTimeException = new \RuntimeException('a runtime exception');
+        $message = [
+            $runTimeException,
+            Logger::LEVEL_ERROR,
+            'application',
+            10,
+            $this->getDummyStackTrace(),
+            123,
+        ];
+        $logMessage = new Yii2LogMessage($message, true);
+
+        $this->assertEquals('RuntimeException: a runtime exception', $logMessage->getMessage());
+        $this->assertEquals($runTimeException, $logMessage->getException());
+        $this->assertArrayHasKey('exception', $logMessage->getContext());
+    }
+
     /**
      * @return array
      */


### PR DESCRIPTION
This is support for Sentry logging with Monolog's `RavenHandler` which uses `exception` key from context to capture exceptions in specific way (foldable stacktrace, different issue's title format). 

![image](https://user-images.githubusercontent.com/600668/47261583-5c350780-d4d2-11e8-9409-7c2369a821e4.png)

Configurable at Yii target level. 100% backward compatible since extracting is disabled by default.